### PR TITLE
Set FT sensor shell as default end-effector tool + fix warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/robot_properties_kuka
+script_dir=$base/lib/robot_properties_kuka
 [install]
-install-scripts=$base/lib/robot_properties_kuka
+install_scripts=$base/lib/robot_properties_kuka

--- a/src/robot_properties_kuka/config.py
+++ b/src/robot_properties_kuka/config.py
@@ -39,7 +39,7 @@ class IiwaConfig(KukaAbstract):
     robot_family = "kuka"   
     robot_name = "iiwa"
 
-    paths = find_paths(robot_name, end_eff='ft_sensor_ball')
+    paths = find_paths(robot_name, end_eff='ft_sensor_shell') # ft_sensor_shell
     meshes_path = paths["package"]
     yaml_path = paths["dgm_yaml"]
     urdf_path = paths["urdf"]


### PR DESCRIPTION
- The end-effector used by default is the plastic shell protecting the FT sensor. It can be changed into a tennis ball, or to none, by editing manually the `end_eff` argument of `find_paths` in `config.py` as follow :
`paths = find_paths(robot_name, end_eff='ft_sensor_ball')  # for the tennis ball`
`paths = find_paths(robot_name, end_eff=None)  # for no end-effector`
In the future we could find a way to let the user specify which URDF to use at the config instantiation level.

- Minor fix of warnings in `setup.cfg`